### PR TITLE
Fixes to examples/simple.py and syris/materials.py

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -6,7 +6,6 @@ import syris
 from syris.physics import propagate
 from syris.bodies.simple import make_sphere
 from syris.materials import make_henke
-from .util import show
 
 
 def main():
@@ -20,7 +19,7 @@ def main():
     sample = make_sphere(n, n / 4 * pixel_size, pixel_size, material=material)
     image = propagate([sample], (n, n), energies, distance, pixel_size).get()
 
-    show(image)
+    plt.imshow(image)
     plt.show()
 
 


### PR DESCRIPTION
On a clean installation, I had problems both with getting the simple.py example to run and with getting the make_stepanov() method in materials.py to run; I need to simulate at > 30 keV, so make_henke() would not work for me.  I modified both files so they now work.